### PR TITLE
Replaced with_fileglob

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,11 +43,15 @@
   become: True
   notify: restart_filebeat
 
+- name: List all disabled modules
+  find:
+    paths: "/etc/filebeat/modules.d"
+    patterns: "*.disabled"
+  register: filebeat_disabled_modules
+
 - name: Erase unmanaged modules
   file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     state: absent
-  with_fileglob:
-    - "/etc/filebeat/modules.d/*.yml.disabled"
+  with_items: "{{ filebeat_disabled_modules.files }}"
   become: True
-  notify: restart_filebeat


### PR DESCRIPTION
with_fileglob works only locally, so disabled modules are not being deleted on remote hosts